### PR TITLE
chore: update to rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,6 @@ keywords = [
     "crates",
 ]
 
-[lints.rust]
-rust_2018_idioms = "warn"
-rust_2021_compatibility = "warn"
-rust_2024_compatibility = "warn"
-
 [features]
 default = []
 dev-support = ["rmp-serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-diet"
 version = "1.3.0"
 authors = ["Sebastian Thiel <byronimo@gmail.com>"]
-edition = "2018"
+edition = "2024"
 repository = "https://github.com/the-lean-crate/cargo-diet"
 include = ["src/**/*", "LICENSE.md", "README.md"]
 license = "MIT"
@@ -19,6 +19,11 @@ keywords = [
     "lean",
     "crates",
 ]
+
+[lints.rust]
+rust_2018_idioms = "warn"
+rust_2021_compatibility = "warn"
+rust_2024_compatibility = "warn"
 
 [features]
 default = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,6 @@
 use bytesize::ByteSize;
+use quick_error::quick_error;
+
 quick_error! {
     #[derive(Debug)]
     pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,11 @@
-#[macro_use]
-extern crate quick_error;
-
-use locate_cargo_manifest::{locate_manifest, LocateManifestError};
+use locate_cargo_manifest::{LocateManifestError, locate_manifest};
 
 mod error;
 mod format_changeset;
 
 use bytesize::ByteSize;
 use criner_waste_report::{
-    tar_path_to_utf8_str, CargoConfig, Fix, Patterns, Report, TarHeader, TarPackage, WastedFile,
+    CargoConfig, Fix, Patterns, Report, TarHeader, TarPackage, WastedFile, tar_path_to_utf8_str,
 };
 pub use error::Error;
 use format_changeset::format_changeset;
@@ -108,13 +105,21 @@ fn edit(
         package,
     );
     match report {
-        Report::Version { total_size_in_bytes, total_files, wasted_files, suggested_fix, .. } => {
+        Report::Version {
+            total_size_in_bytes,
+            total_files,
+            wasted_files,
+            suggested_fix,
+            ..
+        } => {
             if let Some(fix) = suggested_fix {
                 report_savings(total_size_in_bytes, total_files, wasted_files, output).ok();
                 match fix {
                     Fix::EnrichedExclude { exclude, .. } => set_exclude(&mut doc, exclude),
-                    Fix::NewInclude { include, ..} | Fix::ImprovedInclude { include, .. } => set_include(&mut doc, include),
-                    Fix::RemoveExcludeAndUseInclude { include, .. }=> {
+                    Fix::NewInclude { include, .. } | Fix::ImprovedInclude { include, .. } => {
+                        set_include(&mut doc, include)
+                    }
+                    Fix::RemoveExcludeAndUseInclude { include, .. } => {
                         remove_exclude(&mut doc);
                         set_include(&mut doc, include);
                     }
@@ -125,8 +130,10 @@ fn edit(
             } else {
                 report_lean_crate(output).ok();
             }
-        },
-        _ => unreachable!("Reports should always start out as Versions - this should probably not be necessary here"),
+        }
+        _ => unreachable!(
+            "Reports should always start out as Versions - this should probably not be necessary here"
+        ),
     };
     Ok(doc)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ fn entries_to_table(
         .set_header("Size (Byte)")
         .set_align(Align::Right);
 
-    entries.sort_by(|x, y| y.1.cmp(&x.1));
+    entries.sort_by_key(|x| std::cmp::Reverse(x.1));
     let bytes: u64 = entries
         .iter()
         .take(items.unwrap_or(entries.len()))


### PR DESCRIPTION
- use 2024 edition format
- import macro without `#[macro_use]` attribute