### PR TITLE
refactor: use std instead of atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,17 +87,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ef8ee0b4eedc5a877a8a768fecfabbe4c8b9791e17763225139a858dabd8e7"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,7 +209,6 @@ dependencies = [
  "anyhow",
  "argh",
  "ascii_table",
- "atty",
  "byte-unit",
  "bytesize",
  "criner-waste-report",
@@ -363,15 +351,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "indexmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ bytesize = "2.3.1"
 criner-waste-report = { version = "0.1.5", default-features = false }
 ansi_term = "0.12.1"
 difference = "2.0.0"
-atty = "0.2.14"
 ascii_table = "4.0.8"
 termsize = "0.1.6"
 byte-unit = "5.2.0"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -77,6 +77,7 @@ mod args {
 }
 
 use args::{Args, Diet, Subcommands};
+use std::io::IsTerminal;
 
 fn main() -> anyhow::Result<()> {
     let cmd = argh::from_env::<Args>().cmd;
@@ -103,7 +104,7 @@ fn main() -> anyhow::Result<()> {
         cargo_diet::Options {
             reset,
             dry_run,
-            colored_output: atty::is(atty::Stream::Stdout),
+            colored_output: std::io::stdout().is_terminal(),
             list,
             package_size_limit,
             #[cfg(feature = "dev-support")]


### PR DESCRIPTION
`std::io::IsTerminal` is stable since 1.70 and is a drop in replacement. `atty` is unmaintained and has a seemingly minor security advisory opened for it https://rustsec.org/advisories/RUSTSEC-2021-0145.html
