### PR TITLE
chore: fix clippy lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,4 +33,4 @@ jobs:
     - name: fmt
       run: cargo fmt --all -- --check
     - name: clippy
-      run: cargo clippy
+      run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
Fix existing clippy warning and deny on warnings in CI