### PR TITLE
chore: add missing redirect for latest crate resolution

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Check crate package size (with latest binary)
       run: |
         curl -LSfs https://raw.githubusercontent.com/the-lean-crate/cargo-diet/master/ci/install.sh | \
-            sh -s -- --git the-lean-crate/cargo-diet --target x86_64-unknown-linux-musl --force --tag v1.2.5
+            sh -s -- --git the-lean-crate/cargo-diet --target x86_64-unknown-linux-musl --force
 
 
         cargo diet --dry-run --package-size-limit ${{ env.SIZE_LIMIT }}

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -117,7 +117,7 @@ say_err "Crate: $crate"
 url="$url/releases"
 
 if [ -z $tag ]; then
-    tag=$(curl -s "$url/latest" | cut -d'"' -f2 | rev | cut -d'/' -f1 | rev)
+    tag=$(curl -s -o /dev/null -w '%{redirect_url}' "$url/latest" | rev | cut -d'/' -f1 | rev)
     say_err "Tag: latest ($tag)"
 else
     say_err "Tag: $tag"


### PR DESCRIPTION
The install was failing to resolve latest since it wasn't following the redirects. It's currently hard coded to a 1.2.x version for checking the size of the crate

This fails CI since it's hardcoded to master, which has an older install.sh file on it. Looks like the original workaround pushed directly to main so this might need to skip the checks. It could also do the fix then a followup PR 