### PR TITLE
feat: workspace support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      SIZE_LIMIT: 11KB
+      SIZE_LIMIT: 14KB
       CARGO_TERM_COLOR: never
     steps:
     - uses: actions/checkout@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "bytesize",
  "criner-waste-report",
  "flate2",
+ "json",
  "locate-cargo-manifest",
  "quick-error",
  "rmp-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tar = "0.4.46"
 flate2 = "1.1.9"
 rmp-serde = { version = "1.3.1", optional = true }
 argh = "0.1.19"
+json = "0.12.4"
 
 [[bin]]
 name="cargo-diet"

--- a/README.md
+++ b/README.md
@@ -30,8 +30,14 @@ interfering with you on subsequent invocations.
 * **prevent the crate from exceeding a certain package size (best on CI)**
   * `cargo diet -n --package-size-limit 50KB`
   * See the installation instructions specifically for CI, allowing to quickly download a pre-built binary
-  
-  
+
+* **make the workspace lean**
+  * `cargo diet` falls back to the workspace's default members
+  * make a specific package lean: `cargo diet -p my-crate`
+  * make every package lean: `cargo diet --workspace`
+  * make every package lean except a few: `cargo diet --workspace --exclude my-crate`
+
+
 ### Installation
 
 #### Using Cargo

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -57,6 +57,18 @@ mod args {
         /// can happen if big files are placed in currently included directories.
         pub package_size_limit: Option<u64>,
 
+        #[argh(option, short = 'p')]
+        /// package to make lean. like cargo's own `-p`/`--package`
+        pub package: Vec<String>,
+
+        #[argh(switch)]
+        /// make all workspace packages lean
+        pub workspace: bool,
+
+        #[argh(option)]
+        /// exclude the package when `--workspace` is set
+        pub exclude: Vec<String>,
+
         #[argh(option)]
         #[cfg(feature = "dev-support")]
         /// if set, this specifies the path at which a package description for use in criner-waste-report tests should be written to.
@@ -88,6 +100,9 @@ fn main() -> anyhow::Result<()> {
         dry_run,
         list,
         package_size_limit,
+        package,
+        workspace,
+        exclude,
         #[cfg(feature = "dev-support")]
         save_package_for_unit_test,
     }) = cmd;
@@ -107,6 +122,9 @@ fn main() -> anyhow::Result<()> {
             colored_output: std::io::stdout().is_terminal(),
             list,
             package_size_limit,
+            packages: package,
+            workspace,
+            exclude,
             #[cfg(feature = "dev-support")]
             save_package_for_unit_test,
         },

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use bytesize::ByteSize;
 use quick_error::quick_error;
+use std::path::PathBuf;
 
 quick_error! {
     #[derive(Debug)]
@@ -35,5 +36,39 @@ quick_error! {
         LocateManifestExecution(msg: String) {
             display("{}", msg)
         }
+        CargoMetadataError(msg: String) {
+            display("{}", msg)
+        }
+        ExpectedMetadataField(field: &'static str, cargo_version: String) {
+            display("`cargo metadata` missing expected `{}` field. This may mean an outdated cargo version (found: {})", field, cargo_version)
+        }
+        PackageSpecNotFound(spec: String) {
+            display("`{}` did not match any packages", spec)
+        }
+        MissingPackageName(manifest_path: PathBuf) {
+            display("{:?} is missing the required `package.name` field", manifest_path)
+        }
+        JsonParse(err: json::Error) {
+            from()
+            source(err)
+        }
+    }
+}
+
+impl Error {
+    pub(crate) fn message(msg: impl Into<String>) -> Error {
+        Error::Message(msg.into())
+    }
+
+    pub(crate) fn describe_with_chain(&self) -> String {
+        use std::error::Error as _;
+        let mut description = self.to_string();
+        let mut source = self.source();
+        while let Some(err) = source {
+            description.push_str("\n\nCaused by:\n    ");
+            description.push_str(&err.to_string());
+            source = err.source();
+        }
+        description
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use std::{
     io::{BufRead, BufReader, Cursor},
     path::{Path, PathBuf},
     str::FromStr,
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -413,22 +414,41 @@ pub fn execute(options: Options, mut output: impl std::io::Write) -> Result<()> 
     }
 
     let multiple_targets = targets.len() > 1;
-    let options = &options;
-    let results: Vec<(&workspace::Target, Vec<u8>, Result<()>)> = std::thread::scope(|scope| {
-        targets
-            .iter()
-            .map(|target| {
-                scope.spawn(move || {
-                    let mut buf = Vec::new();
-                    let result = execute_for_target(options, target, &mut buf);
-                    (target, buf, result)
+    let results: Vec<(&workspace::Target, Vec<u8>, Result<()>)> = {
+        let options = &options;
+        let parallelism = std::thread::available_parallelism().map_or(1, |count| count.get());
+        let next = AtomicUsize::new(0);
+        std::thread::scope(|scope| {
+            let workers = (0..parallelism.min(targets.len()))
+                .map(|_| {
+                    let next = &next;
+                    let targets = &targets;
+                    scope.spawn(move || {
+                        let mut results = Vec::new();
+                        loop {
+                            let index = next.fetch_add(1, Ordering::Relaxed);
+                            let Some(target) = targets.get(index) else {
+                                break;
+                            };
+                            let mut buf = Vec::new();
+                            let result = execute_for_target(options, target, &mut buf);
+                            results.push((index, target, buf, result));
+                        }
+                        results
+                    })
                 })
-            })
-            .collect::<Vec<_>>()
-            .into_iter()
-            .map(|handle| handle.join().expect("worker thread panicked"))
-            .collect()
-    });
+                .collect::<Vec<_>>();
+            let mut results = workers
+                .into_iter()
+                .flat_map(|worker| worker.join().expect("worker thread panicked"))
+                .collect::<Vec<_>>();
+            results.sort_unstable_by_key(|(index, ..)| *index);
+            results
+                .into_iter()
+                .map(|(_, target, buf, result)| (target, buf, result))
+                .collect()
+        })
+    };
 
     let mut errors = Vec::new();
     for (idx, (target, buf, result)) in results.into_iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
-use locate_cargo_manifest::{LocateManifestError, locate_manifest};
-
 mod error;
 mod format_changeset;
+mod workspace;
 
 use bytesize::ByteSize;
 use criner_waste_report::{
@@ -163,15 +162,7 @@ fn remove_exclude(doc: &mut toml_edit::DocumentMut) {
         .remove("exclude");
 }
 
-fn into_manifest_location_error(err: LocateManifestError) -> Error {
-    if let LocateManifestError::CargoExecution { stderr } = err {
-        Error::LocateManifestExecution(std::str::from_utf8(&stderr).unwrap().to_owned())
-    } else {
-        Error::LocateManifest(err)
-    }
-}
-
-fn tar_package_from_paths(lines: Vec<u8>) -> Result<TarPackage> {
+fn tar_package_from_paths(lines: Vec<u8>, package_root: &Path) -> Result<TarPackage> {
     let mut entries = Vec::new();
     let mut meta_entries = Vec::new();
     let paths = BufReader::new(Cursor::new(lines))
@@ -179,10 +170,12 @@ fn tar_package_from_paths(lines: Vec<u8>) -> Result<TarPackage> {
         .collect::<std::result::Result<Vec<_>, _>>()?;
     let cargo_manifest = CargoConfig::from(
         fs::read_to_string(
-            paths
-                .iter()
-                .find(|p| *p == "Cargo.toml")
-                .expect("cargo manifest"),
+            package_root.join(
+                paths
+                    .iter()
+                    .find(|p| *p == "Cargo.toml")
+                    .expect("cargo manifest"),
+            ),
         )?
         .as_str(),
     );
@@ -205,7 +198,8 @@ fn tar_package_from_paths(lines: Vec<u8>) -> Result<TarPackage> {
         }
 
         const REGULAR_FILE: u8 = b'0';
-        if let Some(meta) = fs::symlink_metadata(&path)
+        let abs_path = package_root.join(&path);
+        if let Some(meta) = fs::symlink_metadata(&abs_path)
             .map(Some)
             .or_else(|err| {
                 if err.kind() == std::io::ErrorKind::NotFound {
@@ -229,7 +223,7 @@ fn tar_package_from_paths(lines: Vec<u8>) -> Result<TarPackage> {
                         size: meta.len(),
                         entry_type: REGULAR_FILE,
                     },
-                    fs::read(path)?,
+                    fs::read(abs_path)?,
                 ))
             }
         }
@@ -240,23 +234,27 @@ fn tar_package_from_paths(lines: Vec<u8>) -> Result<TarPackage> {
     })
 }
 
-fn cargo_package_content() -> Result<TarPackage> {
+pub(crate) fn cargo_command() -> std::process::Command {
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
-    let output = std::process::Command::new(cargo)
+    std::process::Command::new(cargo)
+}
+
+fn cargo_package_content(package_name: &str, package_root: &Path) -> Result<TarPackage> {
+    let output = cargo_command()
         .arg("package")
         .arg("--no-verify")
         .arg("--allow-dirty")
         .arg("--quiet")
         .arg("--list")
+        .arg("--package")
+        .arg(package_name)
         .output()?;
     if !output.status.success() {
         Err(Error::CargoPackageError(
-            std::str::from_utf8(&output.stderr)
-                .map(|s| s.to_owned())
-                .unwrap_or_else(|_| String::from_utf8_lossy(&output.stderr).to_string()),
+            String::from_utf8_lossy(&output.stderr).into_owned(),
         ))
     } else {
-        tar_package_from_paths(output.stdout)
+        tar_package_from_paths(output.stdout, package_root)
     }
 }
 
@@ -319,6 +317,9 @@ pub struct Options {
     pub colored_output: bool,
     pub list: Option<usize>,
     pub package_size_limit: Option<u64>,
+    pub packages: Vec<String>,
+    pub workspace: bool,
+    pub exclude: Vec<String>,
     #[cfg(feature = "dev-support")]
     pub save_package_for_unit_test: Option<PathBuf>,
 }
@@ -326,6 +327,7 @@ pub struct Options {
 fn check_package_size(
     package: TarPackage,
     package_size_limit: u64,
+    package_root: &Path,
     mut output: impl std::io::Write,
     with_color: bool,
 ) -> Result<()> {
@@ -355,7 +357,7 @@ fn check_package_size(
             let path_without_root = tar_path_to_utf8_str(&entry.path);
             header.set_path(base.join(path_without_root))?;
 
-            let mut file = match std::fs::File::open(path_without_root) {
+            let mut file = match std::fs::File::open(package_root.join(path_without_root)) {
                 Ok(f) => f,
                 // Err(err) if err.kind() == std::io::ErrorKind::FilesystemLoop => continue,
                 Err(_) => continue, // for now ignore all errors until we can use the line above
@@ -401,31 +403,101 @@ fn write_package_for_unit_tests(path: Option<PathBuf>, package: &TarPackage) -> 
 }
 
 pub fn execute(options: Options, mut output: impl std::io::Write) -> Result<()> {
-    let manifest_path = locate_manifest().map_err(into_manifest_location_error)?;
+    let targets = workspace::select_targets(&options)?;
 
-    let cargo_manifest_original_content = std::fs::read_to_string(&manifest_path)?;
+    #[cfg(feature = "dev-support")]
+    if targets.len() > 1 && options.save_package_for_unit_test.is_some() {
+        return Err(Error::message(
+            "--save-package-for-unit-test can only be used when a single package is selected",
+        ));
+    }
+
+    let multiple_targets = targets.len() > 1;
+    let options = &options;
+    let results: Vec<(&workspace::Target, Vec<u8>, Result<()>)> = std::thread::scope(|scope| {
+        targets
+            .iter()
+            .map(|target| {
+                scope.spawn(move || {
+                    let mut buf = Vec::new();
+                    let result = execute_for_target(options, target, &mut buf);
+                    (target, buf, result)
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|handle| handle.join().expect("worker thread panicked"))
+            .collect()
+    });
+
+    let mut errors = Vec::new();
+    for (idx, (target, buf, result)) in results.into_iter().enumerate() {
+        if multiple_targets {
+            if idx > 0 {
+                writeln!(output)?;
+            }
+            let with_color = options.colored_output;
+            paint!(
+                output,
+                with_color,
+                ansi_term::Style::new().bold(),
+                "{}\n",
+                target.name
+            );
+        }
+        output.write_all(&buf)?;
+        if let Err(err) = result {
+            if multiple_targets {
+                errors.push(format!(
+                    "package `{}`: {}",
+                    target.name,
+                    err.describe_with_chain()
+                ));
+            } else {
+                return Err(err);
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(Error::message(errors.join("\n\n")))
+    }
+}
+
+fn execute_for_target(
+    options: &Options,
+    target: &workspace::Target,
+    mut output: impl std::io::Write,
+) -> Result<()> {
+    let manifest_path = &target.manifest_path;
+    let package_root = manifest_path.parent().expect("manifest has a parent dir");
+    let package_name = target.name.as_str();
+
+    let cargo_manifest_original_content = std::fs::read_to_string(manifest_path)?;
     let mut document = toml_edit::DocumentMut::from_str(&cargo_manifest_original_content)?;
 
     if options.reset {
         clear_includes_and_excludes(&mut document);
-        std::fs::write(&manifest_path, document.to_string())?;
+        std::fs::write(manifest_path, document.to_string())?;
     }
-    let package = cargo_package_content()?;
+    let package = cargo_package_content(package_name, package_root)?;
 
     #[cfg(feature = "dev-support")]
-    write_package_for_unit_tests(options.save_package_for_unit_test, &package)?;
+    write_package_for_unit_tests(options.save_package_for_unit_test.clone(), &package)?;
     let package_size_limit = options.package_size_limit.map(|s| (package.clone(), s));
     // In dry-run mode, reset the manifest to its original state right after we obtained the package content
     // that saw the reset manifest file, i.e. one without includes or excludes
     if options.reset && options.dry_run {
-        std::fs::write(&manifest_path, &cargo_manifest_original_content)?;
+        std::fs::write(manifest_path, &cargo_manifest_original_content)?;
     }
     let list = options
         .list
         .map(|list| (list, package.entries_meta_data.clone()));
     let document = edit(document, package, &mut output)?;
     write_manifest(
-        &manifest_path,
+        manifest_path,
         document,
         cargo_manifest_original_content,
         options.dry_run,
@@ -437,6 +509,7 @@ pub fn execute(options: Options, mut output: impl std::io::Write) -> Result<()> 
         check_package_size(
             package,
             package_size_limit,
+            package_root,
             &mut output,
             options.colored_output,
         )?;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -147,6 +147,13 @@ fn parse_spec(spec: &str) -> (&str, Option<&str>) {
     }
 }
 
+fn version_matches(version: &str, spec: &str) -> bool {
+    version == spec
+        || version
+            .strip_prefix(spec)
+            .is_some_and(|rest| rest.starts_with('.'))
+}
+
 fn sorted(mut targets: Vec<Target>) -> Vec<Target> {
     targets.sort();
     targets
@@ -176,7 +183,9 @@ pub fn resolve_targets(options: &Options, metadata: &Metadata) -> Result<Vec<Tar
                 metadata
                     .packages
                     .iter()
-                    .find(|p| p.name == name && version.is_none_or(|v| p.version == v))
+                    .find(|p| {
+                        p.name == name && version.is_none_or(|v| version_matches(&p.version, v))
+                    })
                     .ok_or_else(|| Error::PackageSpecNotFound(spec.clone()))
             })
             .collect::<Result<Vec<_>>>()?;
@@ -331,6 +340,17 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, Error::PackageSpecNotFound(spec) if spec == "nope"));
+    }
+
+    #[test]
+    fn dash_p_accepts_partial_versions() {
+        for spec in ["crate-a@0", "crate-a@0.1", "crate-a@0.1.0"] {
+            assert_eq!(
+                resolve_targets(&options_with(vec![spec], false, vec![]), &metadata(vec![]))
+                    .unwrap(),
+                vec![target("crate-a")]
+            );
+        }
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -154,6 +154,11 @@ fn version_matches(version: &str, spec: &str) -> bool {
             .is_some_and(|rest| rest.starts_with('.'))
 }
 
+fn package_matches_spec(package: &Package, spec: &str) -> bool {
+    let (name, version) = parse_spec(spec);
+    package.name == name && version.is_none_or(|v| version_matches(&package.version, v))
+}
+
 fn sorted(mut targets: Vec<Target>) -> Vec<Target> {
     targets.sort();
     targets
@@ -161,11 +166,25 @@ fn sorted(mut targets: Vec<Target>) -> Vec<Target> {
 
 pub fn resolve_targets(options: &Options, metadata: &Metadata) -> Result<Vec<Target>> {
     if options.workspace {
+        for spec in &options.exclude {
+            if !metadata
+                .packages
+                .iter()
+                .any(|package| package_matches_spec(package, spec))
+            {
+                return Err(Error::PackageSpecNotFound(spec.clone()));
+            }
+        }
         return Ok(sorted(
             metadata
                 .packages
                 .iter()
-                .filter(|p| !options.exclude.iter().any(|e| e == &p.name))
+                .filter(|p| {
+                    !options
+                        .exclude
+                        .iter()
+                        .any(|spec| package_matches_spec(p, spec))
+                })
                 .map(|p| Target {
                     name: p.name.clone(),
                     manifest_path: p.manifest_path.clone(),
@@ -179,13 +198,10 @@ pub fn resolve_targets(options: &Options, metadata: &Metadata) -> Result<Vec<Tar
             .packages
             .iter()
             .map(|spec| {
-                let (name, version) = parse_spec(spec);
                 metadata
                     .packages
                     .iter()
-                    .find(|p| {
-                        p.name == name && version.is_none_or(|v| version_matches(&p.version, v))
-                    })
+                    .find(|p| package_matches_spec(p, spec))
                     .ok_or_else(|| Error::PackageSpecNotFound(spec.clone()))
             })
             .collect::<Result<Vec<_>>>()?;
@@ -320,6 +336,20 @@ mod tests {
         )
         .unwrap();
         assert_eq!(targets, vec![target("crate-a")]);
+    }
+
+    #[test]
+    fn exclude_resolves_package_specs_and_rejects_unknown_ones() {
+        let targets = resolve_targets(
+            &options_with(vec![], true, vec!["crate-b@0.1"]),
+            &metadata(vec![]),
+        )
+        .unwrap();
+        assert_eq!(targets, vec![target("crate-a")]);
+
+        let err = resolve_targets(&options_with(vec![], true, vec!["nope"]), &metadata(vec![]))
+            .unwrap_err();
+        assert!(matches!(err, Error::PackageSpecNotFound(spec) if spec == "nope"));
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -36,7 +36,11 @@ pub fn select_targets(options: &Options) -> Result<Vec<Target>> {
     let document = toml_edit::DocumentMut::from_str(&std::fs::read_to_string(&manifest_path)?)?;
     let is_virtual_manifest = !document.contains_key("package");
 
-    let targets = if options.workspace || !options.packages.is_empty() || is_virtual_manifest {
+    let targets = if options.workspace
+        || !options.packages.is_empty()
+        || is_virtual_manifest
+        || document.contains_key("workspace")
+    {
         let metadata = fetch(&manifest_path)?;
         resolve_targets(options, &metadata)?
     } else {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,348 @@
+use crate::{Error, Options, Result};
+use locate_cargo_manifest::{LocateManifestError, locate_manifest};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Package {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub manifest_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Metadata {
+    pub packages: Vec<Package>,
+    pub default_member_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Target {
+    pub name: String,
+    pub manifest_path: PathBuf,
+}
+
+pub fn select_targets(options: &Options) -> Result<Vec<Target>> {
+    if !options.exclude.is_empty() && !options.workspace {
+        return Err(Error::message(
+            "--exclude can only be used together with --workspace",
+        ));
+    }
+
+    let manifest_path = locate_manifest().map_err(into_manifest_location_error)?;
+    let document = toml_edit::DocumentMut::from_str(&std::fs::read_to_string(&manifest_path)?)?;
+    let is_virtual_manifest = !document.contains_key("package");
+
+    let targets = if options.workspace || !options.packages.is_empty() || is_virtual_manifest {
+        let metadata = fetch(&manifest_path)?;
+        resolve_targets(options, &metadata)?
+    } else {
+        let name = document["package"]["name"]
+            .as_str()
+            .ok_or_else(|| Error::MissingPackageName(manifest_path.clone()))?
+            .to_owned();
+        vec![Target {
+            name,
+            manifest_path: manifest_path.clone(),
+        }]
+    };
+
+    if targets.is_empty() {
+        return Err(Error::message("No packages matched"));
+    }
+
+    Ok(targets)
+}
+
+fn into_manifest_location_error(err: LocateManifestError) -> Error {
+    if let LocateManifestError::CargoExecution { stderr } = err {
+        Error::LocateManifestExecution(String::from_utf8_lossy(&stderr).into_owned())
+    } else {
+        Error::LocateManifest(err)
+    }
+}
+
+pub fn fetch(manifest_path: &Path) -> Result<Metadata> {
+    let output = crate::cargo_command()
+        .arg("metadata")
+        .arg("--no-deps")
+        .arg("--format-version")
+        .arg("1")
+        .arg("--manifest-path")
+        .arg(manifest_path)
+        .output()?;
+    if !output.status.success() {
+        return Err(Error::CargoMetadataError(
+            String::from_utf8_lossy(&output.stderr).into_owned(),
+        ));
+    }
+    parse_metadata(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_metadata(text: &str) -> Result<Metadata> {
+    let parsed = json::parse(text)?;
+
+    let packages = parsed["packages"]
+        .members()
+        .map(|p| {
+            Ok(Package {
+                id: require_str(&p["id"], "packages[].id")?.to_owned(),
+                name: require_str(&p["name"], "packages[].name")?.to_owned(),
+                version: require_str(&p["version"], "packages[].version")?.to_owned(),
+                manifest_path: PathBuf::from(require_str(
+                    &p["manifest_path"],
+                    "packages[].manifest_path",
+                )?),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let workspace_default_members = &parsed["workspace_default_members"];
+    if !workspace_default_members.is_array() {
+        return Err(expected_metadata_field("workspace_default_members")?);
+    }
+    let default_member_ids = workspace_default_members
+        .members()
+        .map(|v| require_str(v, "workspace_default_members[]").map(str::to_owned))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(Metadata {
+        packages,
+        default_member_ids,
+    })
+}
+
+fn require_str<'a>(value: &'a json::JsonValue, field: &'static str) -> Result<&'a str> {
+    match value.as_str() {
+        Some(s) => Ok(s),
+        None => Err(expected_metadata_field(field)?),
+    }
+}
+
+fn expected_metadata_field(field: &'static str) -> Result<Error> {
+    Ok(Error::ExpectedMetadataField(field, cargo_version()?))
+}
+
+fn cargo_version() -> Result<String> {
+    let output = crate::cargo_command().arg("--version").output()?;
+    if !output.status.success() {
+        return Err(Error::message(format!(
+            "`cargo --version` failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn parse_spec(spec: &str) -> (&str, Option<&str>) {
+    match spec.split_once('@') {
+        Some((name, version)) => (name, Some(version)),
+        None => (spec, None),
+    }
+}
+
+fn sorted(mut targets: Vec<Target>) -> Vec<Target> {
+    targets.sort();
+    targets
+}
+
+pub fn resolve_targets(options: &Options, metadata: &Metadata) -> Result<Vec<Target>> {
+    if options.workspace {
+        return Ok(sorted(
+            metadata
+                .packages
+                .iter()
+                .filter(|p| !options.exclude.iter().any(|e| e == &p.name))
+                .map(|p| Target {
+                    name: p.name.clone(),
+                    manifest_path: p.manifest_path.clone(),
+                })
+                .collect(),
+        ));
+    }
+
+    if !options.packages.is_empty() {
+        let packages = options
+            .packages
+            .iter()
+            .map(|spec| {
+                let (name, version) = parse_spec(spec);
+                metadata
+                    .packages
+                    .iter()
+                    .find(|p| p.name == name && version.is_none_or(|v| p.version == v))
+                    .ok_or_else(|| Error::PackageSpecNotFound(spec.clone()))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        return Ok(sorted(
+            packages
+                .into_iter()
+                .map(|p| Target {
+                    name: p.name.clone(),
+                    manifest_path: p.manifest_path.clone(),
+                })
+                .collect(),
+        ));
+    }
+
+    Ok(sorted(
+        metadata
+            .packages
+            .iter()
+            .filter(|p| metadata.default_member_ids.contains(&p.id))
+            .map(|p| Target {
+                name: p.name.clone(),
+                manifest_path: p.manifest_path.clone(),
+            })
+            .collect(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TWO_PACKAGES: &str = r#"{
+        "packages": [
+            {"id": "crate-a-id", "name": "crate-a", "version": "0.1.0", "manifest_path": "/ws/crate-a/Cargo.toml"},
+            {"id": "crate-b-id", "name": "crate-b", "version": "0.1.0", "manifest_path": "/ws/crate-b/Cargo.toml"}
+        ],
+        "workspace_default_members": ["crate-a-id"]
+    }"#;
+
+    fn package(name: &str) -> Package {
+        Package {
+            id: format!("{name}-id"),
+            name: name.to_owned(),
+            version: "0.1.0".to_owned(),
+            manifest_path: PathBuf::from(format!("/ws/{name}/Cargo.toml")),
+        }
+    }
+
+    fn target(name: &str) -> Target {
+        Target {
+            name: name.to_owned(),
+            manifest_path: PathBuf::from(format!("/ws/{name}/Cargo.toml")),
+        }
+    }
+
+    fn metadata(default_member_ids: Vec<&str>) -> Metadata {
+        Metadata {
+            packages: vec![package("crate-a"), package("crate-b")],
+            default_member_ids: default_member_ids.into_iter().map(str::to_owned).collect(),
+        }
+    }
+
+    #[test]
+    fn parses_packages_and_default_members() {
+        let parsed = parse_metadata(TWO_PACKAGES).unwrap();
+        assert_eq!(parsed, metadata(vec!["crate-a-id"]));
+    }
+
+    #[test]
+    fn errors_clearly_when_default_members_field_is_missing() {
+        let err =
+            parse_metadata(r#"{"packages": [], "workspace_default_members": null}"#).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ExpectedMetadataField("workspace_default_members", _)
+        ));
+    }
+
+    #[test]
+    fn explicit_empty_default_members_selects_nothing() {
+        let parsed =
+            parse_metadata(r#"{"packages": [], "workspace_default_members": []}"#).unwrap();
+        assert_eq!(parsed.default_member_ids, Vec::<String>::new());
+    }
+
+    #[test]
+    fn errors_clearly_when_a_required_package_field_is_missing() {
+        let err = parse_metadata(
+            r#"{"packages": [{"id": "a-id", "version": "0.1.0", "manifest_path": "/ws/a/Cargo.toml"}], "workspace_default_members": null}"#,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ExpectedMetadataField("packages[].name", _)
+        ));
+    }
+
+    #[test]
+    fn errors_clearly_when_a_default_member_entry_is_not_a_string() {
+        let err =
+            parse_metadata(r#"{"packages": [], "workspace_default_members": [42]}"#).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ExpectedMetadataField("workspace_default_members[]", _)
+        ));
+    }
+
+    fn options_with(packages: Vec<&str>, workspace: bool, exclude: Vec<&str>) -> Options {
+        Options {
+            packages: packages.into_iter().map(str::to_owned).collect(),
+            workspace,
+            exclude: exclude.into_iter().map(str::to_owned).collect(),
+            ..Options::default()
+        }
+    }
+
+    #[test]
+    fn workspace_flag_silently_overrides_dash_p() {
+        let targets = resolve_targets(
+            &options_with(vec!["crate-a"], true, vec![]),
+            &metadata(vec![]),
+        )
+        .unwrap();
+        assert_eq!(targets, vec![target("crate-a"), target("crate-b")]);
+    }
+
+    #[test]
+    fn exclude_applies_on_top_of_workspace() {
+        let targets = resolve_targets(
+            &options_with(vec![], true, vec!["crate-b"]),
+            &metadata(vec![]),
+        )
+        .unwrap();
+        assert_eq!(targets, vec![target("crate-a")]);
+    }
+
+    #[test]
+    fn dash_p_sorts_by_name_rather_than_cli_order() {
+        let targets = resolve_targets(
+            &options_with(vec!["crate-b", "crate-a"], false, vec![]),
+            &metadata(vec![]),
+        )
+        .unwrap();
+        assert_eq!(targets, vec![target("crate-a"), target("crate-b")]);
+    }
+
+    #[test]
+    fn dash_p_errors_on_unknown_spec() {
+        let err = resolve_targets(
+            &options_with(vec!["nope"], false, vec![]),
+            &metadata(vec![]),
+        )
+        .unwrap_err();
+        assert!(matches!(err, Error::PackageSpecNotFound(spec) if spec == "nope"));
+    }
+
+    #[test]
+    fn no_flags_falls_back_to_default_members() {
+        let targets = resolve_targets(
+            &options_with(vec![], false, vec![]),
+            &metadata(vec!["crate-a-id"]),
+        )
+        .unwrap();
+        assert_eq!(targets, vec![target("crate-a")]);
+    }
+
+    #[test]
+    fn no_flags_with_explicit_empty_default_members_selects_nothing() {
+        let targets =
+            resolve_targets(&options_with(vec![], false, vec![]), &metadata(vec![])).unwrap();
+        assert!(targets.is_empty());
+    }
+}

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -17,3 +17,11 @@ function in-clone-of () {
     cd $repo_name
   }
 }
+
+function workspace_member () {
+  local path=${1:?path of the member crate, relative to the workspace root}
+  local name=${2:?package name}
+  mkdir -p "$path/src"
+  printf '[package]\nname = "%s"\nversion = "0.1.0"\nedition = "2021"\n' "$name" > "$path/Cargo.toml"
+  echo "pub fn f() {}" > "$path/src/lib.rs"
+}

--- a/tests/snapshots/failure-invalid-cargo-manifest-due-to-packaging-with-human-readable-error
+++ b/tests/snapshots/failure-invalid-cargo-manifest-due-to-packaging-with-human-readable-error
@@ -3,6 +3,3 @@ Error: error: failed to parse manifest at <redacted>
 Caused by:
   no targets specified in the manifest
   either src/lib.rs, src/main.rs, a [lib] section, or [[bin]] section must be present
-
-
-To try fixing this, run 'cargo package' by hand before running 'cargo diet' again.

--- a/tests/snapshots/failure-workspace-empty-default-members
+++ b/tests/snapshots/failure-workspace-empty-default-members
@@ -1,0 +1,1 @@
+Error: No packages matched

--- a/tests/snapshots/failure-workspace-exclude-without-workspace-flag
+++ b/tests/snapshots/failure-workspace-exclude-without-workspace-flag
@@ -1,0 +1,1 @@
+Error: --exclude can only be used together with --workspace

--- a/tests/snapshots/failure-workspace-excludes-everything
+++ b/tests/snapshots/failure-workspace-excludes-everything
@@ -1,0 +1,1 @@
+Error: No packages matched

--- a/tests/snapshots/failure-workspace-package-size-limit-names-package
+++ b/tests/snapshots/failure-workspace-package-size-limit-names-package
@@ -1,0 +1,21 @@
+crate-a
+Your crate is perfectly lean!
+There would be no change.
+
+crate-b
+┌─────────────────┬─────────────┐
+│ Removed File    │ Size (Byte) │
+├─────────────────┼─────────────┤
+│ src/lib_test.rs │           0 │
+└─────────────────┴─────────────┘
+Saved 0% or <bytecount> in 1 files (of <bytecount> and 3 files in entire crate)
+
+The following change WOULD be made to Cargo.toml:
+Diff - removed / added + :
+[…skipped 2 lines…]
+version = "0.1.0"
+edition = "2021"
++include = ["src/**/*", "!**/*_test.*"]
+Error: package `crate-a`: The actual estimated package size of <bytecount> exceeded the limit of <bytecount> by <bytecount>
+
+package `crate-b`: The actual estimated package size of <bytecount> exceeded the limit of <bytecount> by <bytecount>

--- a/tests/snapshots/failure-workspace-save-package-with-multiple-targets
+++ b/tests/snapshots/failure-workspace-save-package-with-multiple-targets
@@ -1,0 +1,1 @@
+Error: --save-package-for-unit-test can only be used when a single package is selected

--- a/tests/snapshots/failure-workspace-unknown-package
+++ b/tests/snapshots/failure-workspace-unknown-package
@@ -1,0 +1,1 @@
+Error: `does-not-exist` did not match any packages

--- a/tests/snapshots/success-workspace-dash-p
+++ b/tests/snapshots/success-workspace-dash-p
@@ -1,0 +1,2 @@
+Your crate is perfectly lean!
+There would be no change.

--- a/tests/snapshots/success-workspace-default-members
+++ b/tests/snapshots/success-workspace-default-members
@@ -1,0 +1,18 @@
+crate-a
+Your crate is perfectly lean!
+There would be no change.
+
+crate-b
+┌─────────────────┬─────────────┐
+│ Removed File    │ Size (Byte) │
+├─────────────────┼─────────────┤
+│ src/lib_test.rs │           0 │
+└─────────────────┴─────────────┘
+Saved 0% or 0 B in 1 files (of 76 B and 3 files in entire crate)
+
+The following change WOULD be made to Cargo.toml:
+Diff - removed / added + :
+[…skipped 2 lines…]
+version = "0.1.0"
+edition = "2021"
++include = ["src/**/*", "!**/*_test.*"]

--- a/tests/snapshots/success-workspace-excluding-member
+++ b/tests/snapshots/success-workspace-excluding-member
@@ -1,0 +1,2 @@
+Your crate is perfectly lean!
+There would be no change.

--- a/tests/snapshots/success-workspace-member-cwd-no-flags
+++ b/tests/snapshots/success-workspace-member-cwd-no-flags
@@ -1,0 +1,2 @@
+Your crate is perfectly lean!
+There would be no change.

--- a/tests/snapshots/success-workspace-multiple-members-modified
+++ b/tests/snapshots/success-workspace-multiple-members-modified
@@ -1,0 +1,33 @@
+pkg-one
+┌─────────────────┬─────────────┐
+│ Removed File    │ Size (Byte) │
+├─────────────────┼─────────────┤
+│ src/lib_test.rs │           0 │
+└─────────────────┴─────────────┘
+Saved 0% or 0 B in 1 files (of 76 B and 3 files in entire crate)
+
+The following change was made to Cargo.toml:
+Diff - removed / added + :
+[…skipped 2 lines…]
+version = "0.1.0"
+edition = "2021"
++include = ["src/**/*", "!**/*_test.*"]
+
+pkg-three
+Your crate is perfectly lean!
+Nothing changed.
+
+pkg-two
+┌─────────────────┬─────────────┐
+│ Removed File    │ Size (Byte) │
+├─────────────────┼─────────────┤
+│ src/lib_test.rs │           0 │
+└─────────────────┴─────────────┘
+Saved 0% or 0 B in 1 files (of 76 B and 3 files in entire crate)
+
+The following change was made to Cargo.toml:
+Diff - removed / added + :
+[…skipped 2 lines…]
+version = "0.1.0"
+edition = "2021"
++include = ["src/**/*", "!**/*_test.*"]

--- a/tests/snapshots/success-workspace-overrides-dash-p
+++ b/tests/snapshots/success-workspace-overrides-dash-p
@@ -1,0 +1,18 @@
+crate-a
+Your crate is perfectly lean!
+There would be no change.
+
+crate-b
+┌─────────────────┬─────────────┐
+│ Removed File    │ Size (Byte) │
+├─────────────────┼─────────────┤
+│ src/lib_test.rs │           0 │
+└─────────────────┴─────────────┘
+Saved 0% or 0 B in 1 files (of 76 B and 3 files in entire crate)
+
+The following change WOULD be made to Cargo.toml:
+Diff - removed / added + :
+[…skipped 2 lines…]
+version = "0.1.0"
+edition = "2021"
++include = ["src/**/*", "!**/*_test.*"]

--- a/tests/snapshots/success-workspace-pkg-one-cargo-toml
+++ b/tests/snapshots/success-workspace-pkg-one-cargo-toml
@@ -1,0 +1,5 @@
+[package]
+name = "pkg-one"
+version = "0.1.0"
+edition = "2021"
+include = ["src/**/*", "!**/*_test.*"]

--- a/tests/snapshots/success-workspace-pkg-three-cargo-toml
+++ b/tests/snapshots/success-workspace-pkg-three-cargo-toml
@@ -1,0 +1,4 @@
+[package]
+name = "pkg-three"
+version = "0.1.0"
+edition = "2021"

--- a/tests/snapshots/success-workspace-pkg-two-cargo-toml
+++ b/tests/snapshots/success-workspace-pkg-two-cargo-toml
@@ -1,0 +1,5 @@
+[package]
+name = "pkg-two"
+version = "0.1.0"
+edition = "2021"
+include = ["src/**/*", "!**/*_test.*"]

--- a/tests/stateless-journey.sh
+++ b/tests/stateless-journey.sh
@@ -303,6 +303,152 @@ function remove_bytecounts() {
 )
 
 (sandbox
+  (with "a cargo workspace whose members are declared via a glob, one of which needs a leaner include directive"
+    step "set up workspace" && {
+      cat <<EOF > Cargo.toml
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+EOF
+      workspace_member crates/crate-a crate-a
+      workspace_member crates/crate-b crate-b
+      touch crates/crate-b/src/lib_test.rs
+    }
+
+    (when "running it at the workspace root with no package selection flags"
+      it "processes every workspace member, mirroring cargo's own default-members behavior" && {
+        WITH_SNAPSHOT="$snapshot/success-workspace-default-members" \
+        expect_run ${SUCCESSFULLY} "$exe" diet -n
+      }
+    )
+
+    (when "running it with -p crate-a"
+      it "only processes the selected package" && {
+        WITH_SNAPSHOT="$snapshot/success-workspace-dash-p" \
+        expect_run ${SUCCESSFULLY} "$exe" diet -n -p crate-a
+      }
+    )
+
+    (when "running it with -p pointing at a package that does not exist"
+      it "fails with a cargo-like error message" && {
+        WITH_SNAPSHOT="$snapshot/failure-workspace-unknown-package" \
+        expect_run ${WITH_FAILURE} "$exe" diet -n -p does-not-exist
+      }
+    )
+
+    (when "running it from within a workspace member directory, with no flags"
+      it "still only touches that one member, as it did before workspaces were supported" && (
+        cd crates/crate-a
+        WITH_SNAPSHOT="$snapshot/success-workspace-member-cwd-no-flags" \
+        expect_run ${SUCCESSFULLY} "$exe" diet -n
+      )
+    )
+
+    (when "running it with --save-package-for-unit-test and more than one package selected"
+      it "refuses, since that flag can only write a single package description" && {
+        WITH_SNAPSHOT="$snapshot/failure-workspace-save-package-with-multiple-targets" \
+        expect_run ${WITH_FAILURE} "$exe" diet -n --workspace --save-package-for-unit-test out.rmp
+      }
+    )
+
+    (when "running it with -p crate-b --workspace together"
+      it "lets --workspace silently override -p, just like cargo itself does" && {
+        WITH_SNAPSHOT="$snapshot/success-workspace-overrides-dash-p" \
+        expect_run ${SUCCESSFULLY} "$exe" diet -n -p crate-b --workspace
+      }
+    )
+
+    (when "running it with --workspace --exclude crate-b"
+      it "processes every member except the excluded one" && {
+        WITH_SNAPSHOT="$snapshot/success-workspace-excluding-member" \
+        expect_run ${SUCCESSFULLY} "$exe" diet -n --workspace --exclude crate-b
+      }
+    )
+
+    (when "running it with --exclude but without --workspace"
+      it "fails just like cargo itself does in this case" && {
+        WITH_SNAPSHOT="$snapshot/failure-workspace-exclude-without-workspace-flag" \
+        expect_run ${WITH_FAILURE} "$exe" diet -n --exclude crate-b
+      }
+    )
+
+    (when "running it with --workspace, excluding every member"
+      it "fails instead of silently doing nothing, just like cargo itself does in this case" && {
+        WITH_SNAPSHOT="$snapshot/failure-workspace-excludes-everything" \
+        expect_run ${WITH_FAILURE} "$exe" diet -n --workspace --exclude crate-a --exclude crate-b
+      }
+    )
+
+    (when "running it with --workspace and a --package-size-limit that crate-a exceeds"
+      it "names the offending package in the error, since with several packages in play that's no longer obvious" && {
+        SNAPSHOT_FILTER=remove_bytecounts \
+        WITH_SNAPSHOT="$snapshot/failure-workspace-package-size-limit-names-package" \
+        expect_run ${WITH_FAILURE} "$exe" diet -n --workspace --package-size-limit 1B
+      }
+    )
+  )
+)
+
+(sandbox
+  (with "a cargo workspace with explicit member paths and several subcrates, two of which need a leaner include directive"
+    step "set up workspace" && {
+      cat <<EOF > Cargo.toml
+[workspace]
+members = ["pkg-one", "pkg-two", "pkg-three"]
+resolver = "2"
+EOF
+      workspace_member pkg-one pkg-one
+      touch pkg-one/src/lib_test.rs
+
+      workspace_member pkg-two pkg-two
+      touch pkg-two/src/lib_test.rs
+
+      workspace_member pkg-three pkg-three
+    }
+
+    (when "running it with --workspace, with NO --dry-run flag set"
+      it "runs successfully and reports each package in turn" && {
+        WITH_SNAPSHOT="$snapshot/success-workspace-multiple-members-modified" \
+        expect_run ${SUCCESSFULLY} "$exe" diet --workspace
+      }
+
+      it "adds the include directive to pkg-one's manifest" && {
+        expect_snapshot "$snapshot/success-workspace-pkg-one-cargo-toml" "pkg-one/Cargo.toml"
+      }
+
+      it "adds the include directive to pkg-two's manifest" && {
+        expect_snapshot "$snapshot/success-workspace-pkg-two-cargo-toml" "pkg-two/Cargo.toml"
+      }
+
+      it "leaves pkg-three's manifest untouched, since it was already lean" && {
+        expect_snapshot "$snapshot/success-workspace-pkg-three-cargo-toml" "pkg-three/Cargo.toml"
+      }
+    )
+  )
+)
+
+(sandbox
+  (with "a cargo workspace that explicitly declares no default members"
+    step "set up workspace" && {
+      cat <<EOF > Cargo.toml
+[workspace]
+members = ["crate-a"]
+default-members = []
+resolver = "2"
+EOF
+      workspace_member crate-a crate-a
+    }
+
+    (when "running it at the workspace root with no package selection flags"
+      it "fails, since cargo itself packages nothing in this case rather than falling back to every member" && {
+        WITH_SNAPSHOT="$snapshot/failure-workspace-empty-default-members" \
+        expect_run ${WITH_FAILURE} "$exe" diet -n
+      }
+    )
+  )
+)
+
+(sandbox
   (with "a newly initialized cargo project with several dependencies"
     step "init cargo project" &&
       expect_run ${SUCCESSFULLY} cargo init --edition 2018 --name library --bin


### PR DESCRIPTION
Mirrors `cargo`'s workspace flags (`--workspace`, `--exclude`, `--package`). Requires cargo > 1.70, which is around 3 years old

Tested on a 60 crate workspace (https://github.com/oxc-project/oxc/pull/24932), and it ran in 3.1 seconds

closes #54 