### PR TITLE
ci: add zizmor security scan for GitHub Actions workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,3 +44,19 @@ jobs:
       run: cargo fmt --all -- --check
     - name: clippy
       run: cargo clippy --all-targets -- -D warnings
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3


### PR DESCRIPTION
- Add a zizmor job to rust.yml that scans GitHub Actions workflows for security issues
- Upload findings as SARIF to code scanning