### PR TITLE
chore(ci): trim Windows release targets to msvc x86_64 and arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
       - name: Get the release version from the tag
         if: env.ARTIFACT_VERSION == ''
-        run: |
-          echo "ARTIFACT_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "version is: $ARTIFACT_VERSION"
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "ARTIFACT_VERSION=$REF_NAME" >> "$GITHUB_ENV"
 
       - name: Set version output
         id: version
@@ -143,7 +143,7 @@ jobs:
           MATRIX_TARGET: ${{ matrix.target }}
         run: |
           staging="${EXE_NAME}-${RELEASE_VERSION}-${MATRIX_TARGET}"
-          mkdir -p "$staging"/complete
+          mkdir -p "$staging"
 
           cp {README.md,LICENSE.md,CHANGELOG.md} "$staging/"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       EXE_NAME: cargo-diet
     strategy:
       matrix:
-        build: [linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc]
+        build: [linux, linux-arm, macos, win-msvc, win-arm64-msvc]
         include:
           - build: linux
             os: ubuntu-latest
@@ -79,17 +79,13 @@ jobs:
             rust: stable
             target: x86_64-apple-darwin
           - build: win-msvc
-            os: windows-2019
-            rust: nightly
+            os: windows-latest
+            rust: stable
             target: x86_64-pc-windows-msvc
-          - build: win-gnu
-            os: windows-2019
-            rust: nightly-x86_64-gnu
-            target: x86_64-pc-windows-gnu
-          - build: win32-msvc
-            os: windows-2019
-            rust: nightly
-            target: i686-pc-windows-msvc
+          - build: win-arm64-msvc
+            os: windows-latest
+            rust: stable
+            target: aarch64-pc-windows-msvc
 
     steps:
       - name: Checkout repository
@@ -115,7 +111,6 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Use Cross
-        # if: matrix.os != 'windows-2019'
         run: |
           cargo install cross
           echo "CARGO=cross" >> $GITHUB_ENV
@@ -152,9 +147,10 @@ jobs:
 
           cp {README.md,LICENSE.md,CHANGELOG.md} "$staging/"
 
-          if [ "${{ matrix.os }}" = "windows-2019" ]; then
-            # cp "target/${{ matrix.target }}/release/${{ env.EXE_NAME }}.exe" "$staging/"
-            cp "target/release/${{ env.EXE_NAME }}.exe" "$staging/"
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            bin_dir="target/${MATRIX_TARGET}/release"
+            [ -f "$bin_dir/${EXE_NAME}.exe" ] || bin_dir="target/release"
+            cp "$bin_dir/${EXE_NAME}.exe" "$staging/"
             7z a "$staging.zip" "$staging"
             echo "ASSET=$staging.zip" >> $GITHUB_ENV
           else


### PR DESCRIPTION
- Drop win-gnu and win32-msvc targets, move remaining Windows build off deprecated windows-2019 to windows-latest + stable, add aarch64-pc-windows-msvc
- Make the Windows binary path lookup robust to cross-arch builds landing under target/<triple>/release instead of target/release
- Use github.ref_name instead of manual ref parsing; drop dead staging complete dir