### PR TITLE
chore(ci): publish to crates.io via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,3 +164,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: gh release upload "$RELEASE_VERSION" "$ASSET" --clobber
+
+  publish-crate:
+    name: publish-crate
+    needs: ["build-release"]
+    runs-on: ubuntu-latest
+    environment: publish
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish


### PR DESCRIPTION
- Add publish-crate job after build-release: authenticates to crates.io via OIDC (id-token: write, no long-lived token stored in repo secrets)
- Requires crates.io trusted publishing configured for this repo/workflow before it can run

closes #79 