### PR TITLE
chore: replace deprecated ansi_term with nu-ansi-term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,15 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,7 +196,6 @@ checksum = "7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b"
 name = "cargo-diet"
 version = "1.4.0"
 dependencies = [
- "ansi_term",
  "anyhow",
  "argh",
  "ascii_table",
@@ -215,6 +205,7 @@ dependencies = [
  "flate2",
  "json",
  "locate-cargo-manifest",
+ "nu-ansi-term",
  "quick-error",
  "rmp-serde",
  "similar",
@@ -437,6 +428,15 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ locate-cargo-manifest = "0.2.2"
 toml_edit = "0.25.12"
 bytesize = "2.3.1"
 criner-waste-report = { version = "0.1.5", default-features = false }
-ansi_term = "0.12.1"
 similar = "3.1.1"
 ascii_table = "4.0.8"
 termsize = "0.1.6"
@@ -41,6 +40,7 @@ flate2 = "1.1.9"
 rmp-serde = { version = "1.3.1", optional = true }
 argh = "0.1.19"
 json = "0.12.4"
+nu-ansi-term = "0.50.3"
 
 [[bin]]
 name="cargo-diet"

--- a/src/format_changeset.rs
+++ b/src/format_changeset.rs
@@ -2,8 +2,8 @@
 //! (License MIT)
 //! and adapted from https://github.com/johannhof/difference.rs/blob/c5749ad7d82aa3d480c15cb61af9f6baa08f116f/examples/line-by-line.rs
 //! (License MIT)
-use ansi_term::Colour::{Green, Red};
-use ansi_term::Style;
+use nu_ansi_term::Color::{Green, Red};
+use nu_ansi_term::Style;
 use similar::{ChangeTag, TextDiff};
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ fn write_manifest(
         paint!(
             output,
             with_color,
-            ansi_term::Style::new().dimmed(),
+            nu_ansi_term::Style::new().dimmed(),
             "{}\n",
             if dry_run {
                 "There would be no change."
@@ -294,7 +294,7 @@ fn write_manifest(
         paint!(
             output,
             with_color,
-            ansi_term::Style::new().dimmed(),
+            nu_ansi_term::Style::new().dimmed(),
             "{}\n",
             if dry_run {
                 "The following change WOULD be made to Cargo.toml:"
@@ -382,7 +382,7 @@ fn check_package_size(
     paint!(
         output,
         with_color,
-        ansi_term::Colour::Green,
+        nu_ansi_term::Color::Green,
         "{}\n",
         format!(
             "The estimated actual package size of {} is within the limit of {}.",
@@ -461,7 +461,7 @@ pub fn execute(options: Options, mut output: impl std::io::Write) -> Result<()> 
             paint!(
                 output,
                 with_color,
-                ansi_term::Style::new().bold(),
+                nu_ansi_term::Style::new().bold(),
                 "{}\n",
                 target.name
             );


### PR DESCRIPTION
Swap ansi_term (unmaintained, RUSTSEC-2021-0139) for nu-ansi-term
