### PR TITLE
chore(ci): run Upload release archive under bash on Windows runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,7 @@ jobs:
           fi
 
       - name: Upload release archive
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
- Add shell: bash to the Upload release archive step
- v1.4.1's release run showed linux/macos/linux-arm uploading fine while both Windows targets failed here, because pwsh (the windows-latest default shell) doesn't expand bare \$RELEASE_VERSION/\$ASSET