### PR TITLE
chore: inline locate-cargo-manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,6 @@ dependencies = [
  "criner-waste-report",
  "flate2",
  "json",
- "locate-cargo-manifest",
  "nu-ansi-term",
  "quick-error",
  "rmp-serde",
@@ -227,15 +226,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "locate-cargo-manifest"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db985b63431fe09e8d71f50aeceffcc31e720cb86be8dad2f38d084c5a328466"
-dependencies = [
- "json",
-]
 
 [[package]]
 name = "log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ dev-support = ["rmp-serde"]
 [dependencies]
 anyhow = "1.0.102"
 quick-error = "2.0.1"
-locate-cargo-manifest = "0.2.2"
 toml_edit = "0.25.12"
 bytesize = "2.3.1"
 criner-waste-report = { version = "0.1.5", default-features = false }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,10 +29,6 @@ quick_error! {
             display("Could not open {:?} for reading file meta-data", path)
             source(err)
         }
-        LocateManifest(err: locate_cargo_manifest::LocateManifestError) {
-            from()
-            source(err)
-        }
         LocateManifestExecution(msg: String) {
             display("{}", msg)
         }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,5 +1,4 @@
 use crate::{Error, Options, Result};
-use locate_cargo_manifest::{LocateManifestError, locate_manifest};
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
@@ -33,7 +32,7 @@ pub fn select_targets(options: &Options) -> Result<Vec<Target>> {
         ));
     }
 
-    let manifest_path = locate_manifest().map_err(into_manifest_location_error)?;
+    let manifest_path = locate_manifest()?;
     let document = toml_edit::DocumentMut::from_str(&std::fs::read_to_string(&manifest_path)?)?;
     let is_virtual_manifest = !document.contains_key("package");
 
@@ -62,12 +61,19 @@ pub fn select_targets(options: &Options) -> Result<Vec<Target>> {
     Ok(targets)
 }
 
-fn into_manifest_location_error(err: LocateManifestError) -> Error {
-    if let LocateManifestError::CargoExecution { stderr } = err {
-        Error::LocateManifestExecution(String::from_utf8_lossy(&stderr).into_owned())
-    } else {
-        Error::LocateManifest(err)
+fn locate_manifest() -> Result<PathBuf> {
+    let output = crate::cargo_command().arg("locate-project").output()?;
+    if !output.status.success() {
+        return Err(Error::LocateManifestExecution(
+            String::from_utf8_lossy(&output.stderr).into_owned(),
+        ));
     }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed = json::parse(&stdout)?;
+    let root = parsed["root"].as_str().ok_or_else(|| {
+        Error::message("`cargo locate-project` output is missing the \"root\" field")
+    })?;
+    Ok(PathBuf::from(root))
 }
 
 pub fn fetch(manifest_path: &Path) -> Result<Metadata> {


### PR DESCRIPTION
Inlines the locate-cargo-manifest crate. It's unmaintained, and only about 40 lines

This sets us up well for replacing `json`, another unmaintained crate on top 