### PR TITLE
chore: bump ascii_table to v5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,12 @@ dependencies = [
 
 [[package]]
 name = "ascii_table"
-version = "4.0.8"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ef8ee0b4eedc5a877a8a768fecfabbe4c8b9791e17763225139a858dabd8e7"
+checksum = "2bcff894f0b9ba3bdd4c497c3c39df9662a0eedddf33e872ab29a3bda7167119"
+dependencies = [
+ "termize",
+]
 
 [[package]]
 name = "autocfg"
@@ -104,7 +107,6 @@ dependencies = [
  "rmp-serde",
  "similar",
  "tar",
- "termsize",
  "toml_edit",
 ]
 
@@ -440,13 +442,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "termsize"
-version = "0.1.9"
+name = "termize"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f11ff5c25c172608d5b85e2fb43ee9a6d683a7f4ab7f96ae07b3d8b590368fd"
+checksum = "61946f539e9ff67cbc8df5b2e9823d84e0d58d74e342707c2dfb85405995827b"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -506,28 +508,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ toml_edit = "0.25.12"
 bytesize = "2.3.1"
 criner-waste-report = { version = "0.1.5", default-features = false }
 similar = "3.1.1"
-ascii_table = "4.0.8"
-termsize = "0.1.6"
+ascii_table = { version = "5.0.0", features = ["auto_table_width"] }
 tar = "0.4.46"
 flate2 = "1.1.9"
 rmp-serde = { version = "1.3.1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,14 +60,8 @@ fn entries_to_table(
         return Ok(0);
     }
     use ascii_table::{Align, AsciiTable};
-    use std::fmt::Display;
 
     let mut ascii_table = AsciiTable::default();
-    ascii_table.set_max_width(
-        termsize::get()
-            .unwrap_or(termsize::Size { rows: 20, cols: 80 })
-            .cols as usize,
-    );
     ascii_table
         .column(0)
         .set_header("Removed File")
@@ -84,13 +78,13 @@ fn entries_to_table(
         .rev()
         .map(|(_, size)| size)
         .sum();
-    let data: Vec<Vec<&dyn Display>> = entries
+    let data: Vec<Vec<String>> = entries
         .iter()
         .take(items.unwrap_or(entries.len()))
         .rev()
-        .map(|(path, size)| vec![path as &dyn Display, size as &dyn Display])
+        .map(|(path, size)| vec![path.clone(), size.to_string()])
         .collect();
-    out.write_all(ascii_table.format(data).as_bytes())?;
+    ascii_table.writeln(&mut out, data)?;
     Ok(bytes)
 }
 


### PR DESCRIPTION
Bump to v5, which includes auto table sizing, so we can avoid direct dependence on termsize!

This uses termize, which seems to be lighter anways

This does change the default terminal width to 100 columns, but this should only affect things like tests, and otherwise no one should be reliant on the default width for anything, so it's fine as a patch in my opinion