### PR TITLE
chore: replace quick-error with thiserror, drop anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
 name = "argh"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,7 +89,6 @@ checksum = "7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b"
 name = "cargo-diet"
 version = "1.4.1"
 dependencies = [
- "anyhow",
  "argh",
  "ascii_table",
  "bytesize",
@@ -103,10 +96,10 @@ dependencies = [
  "flate2",
  "json",
  "nu-ansi-term",
- "quick-error",
  "rmp-serde",
  "similar",
  "tar",
+ "thiserror",
  "toml_edit",
 ]
 
@@ -279,12 +272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +436,26 @@ checksum = "61946f539e9ff67cbc8df5b2e9823d84e0d58d74e342707c2dfb85405995827b"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,6 @@ default = []
 dev-support = ["rmp-serde"]
 
 [dependencies]
-anyhow = "1.0.102"
-quick-error = "2.0.1"
 toml_edit = "0.25.12"
 bytesize = "2.3.1"
 criner-waste-report = { version = "0.1.5", default-features = false }
@@ -38,6 +36,7 @@ rmp-serde = { version = "1.3.1", optional = true }
 argh = "0.1.19"
 json = "0.12.4"
 nu-ansi-term = "0.50.3"
+thiserror = "2.0.20"
 
 [[bin]]
 name="cargo-diet"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -90,7 +90,14 @@ mod args {
 use args::{Args, Diet, Subcommands};
 use std::io::IsTerminal;
 
-fn main() -> anyhow::Result<()> {
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("Error: {}", err.describe_with_chain());
+        std::process::exit(1);
+    }
+}
+
+fn run() -> cargo_diet::Result<()> {
     let cmd = argh::from_env::<Args>().cmd;
     let Subcommands::Diet(Diet {
         version,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,54 +1,44 @@
 use bytesize::ByteSize;
-use quick_error::quick_error;
 use std::path::PathBuf;
+use thiserror::Error as ThisError;
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum Error {
-        Bug(d: &'static str) {
-            display("{}", d)
-        }
-        Message(d: String) {
-            display("{}", d)
-        }
-        CargoPackageError(msg: String) {
-            display("{}\n\nTo try fixing this, run 'cargo package' by hand before running 'cargo diet' again.", msg)
-        }
-        TomlParse(err: toml_edit::TomlError) {
-            from()
-            source(err)
-        }
-        Io(err: std::io::Error) {
-            from()
-            source(err)
-        }
-        PackageSizeLimitExceeded(actual_in_bytes: u64, limit_in_bytes: u64) {
-            display("The actual estimated package size of {} exceeded the limit of {} by {}", ByteSize(*actual_in_bytes).display().si(), ByteSize(*limit_in_bytes).display().si(), ByteSize(actual_in_bytes.saturating_sub(*limit_in_bytes)).display().si())
-        }
-        FileMetadata(err: std::io::Error, path: String) {
-            display("Could not open {:?} for reading file meta-data", path)
-            source(err)
-        }
-        LocateManifestExecution(msg: String) {
-            display("{}", msg)
-        }
-        CargoMetadataError(msg: String) {
-            display("{}", msg)
-        }
-        ExpectedMetadataField(field: &'static str, cargo_version: String) {
-            display("`cargo metadata` missing expected `{}` field. This may mean an outdated cargo version (found: {})", field, cargo_version)
-        }
-        PackageSpecNotFound(spec: String) {
-            display("`{}` did not match any packages", spec)
-        }
-        MissingPackageName(manifest_path: PathBuf) {
-            display("{:?} is missing the required `package.name` field", manifest_path)
-        }
-        JsonParse(err: json::Error) {
-            from()
-            source(err)
-        }
-    }
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("{0}")]
+    Bug(&'static str),
+    #[error("{0}")]
+    Message(String),
+    #[error(
+        "{0}\n\nTo try fixing this, run 'cargo package' by hand before running 'cargo diet' again."
+    )]
+    CargoPackageError(String),
+    #[error(transparent)]
+    TomlParse(#[from] toml_edit::TomlError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(
+        "The actual estimated package size of {} exceeded the limit of {} by {}",
+        ByteSize(*.0).display().si(),
+        ByteSize(*.1).display().si(),
+        ByteSize(.0.saturating_sub(*.1)).display().si()
+    )]
+    PackageSizeLimitExceeded(u64, u64),
+    #[error("Could not open {1:?} for reading file meta-data")]
+    FileMetadata(#[source] std::io::Error, String),
+    #[error("{0}")]
+    LocateManifestExecution(String),
+    #[error("{0}")]
+    CargoMetadataError(String),
+    #[error(
+        "`cargo metadata` missing expected `{0}` field. This may mean an outdated cargo version (found: {1})"
+    )]
+    ExpectedMetadataField(&'static str, String),
+    #[error("`{0}` did not match any packages")]
+    PackageSpecNotFound(String),
+    #[error("{0:?} is missing the required `package.name` field")]
+    MissingPackageName(PathBuf),
+    #[error(transparent)]
+    JsonParse(#[from] json::Error),
 }
 
 impl Error {
@@ -56,7 +46,7 @@ impl Error {
         Error::Message(msg.into())
     }
 
-    pub(crate) fn describe_with_chain(&self) -> String {
+    pub fn describe_with_chain(&self) -> String {
         use std::error::Error as _;
         let mut description = self.to_string();
         let mut source = self.source();

--- a/tests/snapshots/failure-invalid-cargo-manifest
+++ b/tests/snapshots/failure-invalid-cargo-manifest
@@ -1,9 +1,5 @@
-Error: TomlParse(TomlError { message: "key with no value, expected `=`", input: Some("foobar\n"), keys: [], span: Some(6..6) })
-
-Caused by:
-    TOML parse error at line 1, column 7
-      |
-    1 | foobar
-      |       ^
-    key with no value, expected `=`
-    
+Error: TOML parse error at line 1, column 7
+  |
+1 | foobar
+  |       ^
+key with no value, expected `=`


### PR DESCRIPTION
quick-error is perfectly serviceable, but allows debug message leakage

thiserror enforces display impls. thiserror is more maintained, which is a mild advantage too

Describe with chain lets us drop anyhow entirely
